### PR TITLE
Timestamp header

### DIFF
--- a/rest_framework_httpsignature/authentication.py
+++ b/rest_framework_httpsignature/authentication.py
@@ -31,11 +31,11 @@ class SignatureAuthentication(authentication.BaseAuthentication):
     authentication for your particular use case:
 
     :param www_authenticate_realm:  Default: "api"
-    :param required_headers:        Default: ["(request-target)", "date"]
+    :param required_headers:        Default: ["(request-target)", "timestamp"]
     """
 
     www_authenticate_realm = "api"
-    required_headers = ["(request-target)", "date"]
+    required_headers = ["(request-target)", "timestamp"]
 
     def fetch_user_data(self, keyId, algorithm=None):
         """Retuns a tuple (User, secret) or (None, None)."""

--- a/rest_framework_httpsignature/middleware.py
+++ b/rest_framework_httpsignature/middleware.py
@@ -13,6 +13,13 @@ except ImportError:
     import hmac
 
 
+# Micropython implementations of time() use different epoch starts:
+# 1970-01-01 on Unix
+# 2001-01-01 on devices
+# We use 2001-01-01 00:00:00 UTC for Timestamp header.
+EPOCH = 978307200
+
+
 class HMACMiddleware(MiddlewareMixin):
 
     #def process_request(self, request):
@@ -26,7 +33,7 @@ class HMACMiddleware(MiddlewareMixin):
         Add the headers
         """
         try:
-            response['Timestamp'] = str(int(time.time()))
+            response['Timestamp'] = str(int(time.time() - EPOCH))
             hmac_instance = hmac.new(request.auth.encode('utf-8'), digestmod='sha256')
             authenticated = True
         except TypeError:


### PR DESCRIPTION
- Using `Timestamp: int` header instead of `Date` for HMAC.

- `HMACMiddleware` adds `Timestamp` header automatically.